### PR TITLE
fix(docs/application): Fix formatting in "Using Traits in Verticles" tutorial

### DIFF
--- a/docs/application/tutorials/203-using-traits-in-verticles.mdx
+++ b/docs/application/tutorials/203-using-traits-in-verticles.mdx
@@ -248,7 +248,7 @@ You can also write your own traits not only for Verticles but much more types.
 </Reference>
 
 <Reference to="https://javadoc.io/doc/de.wuespace.telestion/telestion-api/latest/de/wuespace/telestion/api/verticle/trait/WithEventBus.html">
-	`WithEventBus` API reference
+	<code>WithEventBus</code> API reference
 </Reference>
 
 <Reference to="/application/guides/writing-your-own-traits/">


### PR DESCRIPTION
### Summary <!-- Summarize the content of the pull request in one sentence -->

`<Reference />` can't take Markdown unless there's a line in between -> use HTML for code formatting

### Details <!-- Describe the content of the pull request -->

n/a

### Additional information <!-- Addtional information about the pull request, such as review instructions, screenshots, etc. -->

n/a

### Related links <!-- Related resources, issues and pull requests -->

### CLA

- [x] I have signed the individual contributor's license agreement **and sent** it to the board of the WüSpace e. V. organization.
